### PR TITLE
Allow startup with missing config file

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -7,7 +7,14 @@ florb::settings::settings()
     m_cfgfile = florb::utils::appdir() + florb::utils::pathsep() + "config";
     florb::utils::mkdir(florb::utils::appdir());
 
-    m_rootnode = YAML::LoadFile(m_cfgfile);
+    if (florb::utils::exists(m_cfgfile))
+    {
+        m_rootnode = YAML::LoadFile(m_cfgfile);
+    }
+    else
+    {
+        m_rootnode = YAML::Node();
+    }
     defaults(m_cfgfile);
 }
 


### PR DESCRIPTION
Initial startup without a config file fails with a yaml-cpp exception,
use an empty node instead of crashing.